### PR TITLE
Fix unclosed code block in pgsql18-primary-rocky10 README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ pgopr-images was created by the following authors:
 
 Jesper Pedersen <jesperpedersen.db@gmail.com>
 Bhawesh Panwar <panwarbhawesh1112@gmail.com>
+Frank Heikens <frank@elevarq.com>

--- a/pgsql18-primary-rocky10/README.md
+++ b/pgsql18-primary-rocky10/README.md
@@ -16,6 +16,7 @@ psql -h localhost -p 5432 -U myuser mydb
 
 # Shell to postgresql-primary
 podman exec -it postgresql-primary /usr/bin/bash
+```
 
 ## Configuration
 


### PR DESCRIPTION
The code block opened in `pgsql18-primary-rocky10/README.md` is not closed.

This causes the following sections to render as part of the code block instead
of normal markdown.

Add the missing closing fence after the Getting Started commands.

No functional change.