### PR TITLE
Add .dockerignore for image build contexts

### DIFF
--- a/pgmoneta-rocky10/.dockerignore
+++ b/pgmoneta-rocky10/.dockerignore
@@ -1,0 +1,2 @@
+Makefile
+README.md

--- a/pgsql18-primary-rocky10/.dockerignore
+++ b/pgsql18-primary-rocky10/.dockerignore
@@ -1,0 +1,2 @@
+Makefile
+README.md


### PR DESCRIPTION
Each image is built from inside its own subdirectory (`podman build .`),
so the build context is the image subdirectory, not the repository root.

Add a `.dockerignore` in each image subdirectory to exclude files that
are not used by the Dockerfile (`Makefile`, `README.md`). All files
referenced by `COPY` instructions (`root/`, `conf/`) are preserved.

No change to image contents or build behavior.