### PR TITLE
[#11] Fix pgmoneta Dockerfile build failure

### DIFF
--- a/pgmoneta-rocky10/Dockerfile
+++ b/pgmoneta-rocky10/Dockerfile
@@ -26,7 +26,7 @@ RUN useradd -ms /bin/bash pgmoneta
 COPY root/ /
 RUN chmod +x /usr/bin/run-pgmoneta  
 
-RUN mkdir -p /pgconf /pgmoneta \
+RUN mkdir -p /pgconf /pgmoneta
 COPY conf/* /conf/  
 RUN chown -R pgmoneta:pgmoneta /conf /pgconf /pgmoneta  
 RUN chmod 700 /conf /pgconf /pgmoneta  


### PR DESCRIPTION
Fixes #11.

Line 29 has a trailing backslash after the mkdir command. This causes the
COPY instruction on the next line to be parsed as arguments to mkdir
instead of a separate Dockerfile instruction. Remove the trailing
backslash so the build succeeds.