### PR TITLE
[#12] Use placeholder tokens in postgresql.conf for env var substitution

### DIFF
--- a/pgsql18-primary-rocky10/conf/postgresql.conf
+++ b/pgsql18-primary-rocky10/conf/postgresql.conf
@@ -62,7 +62,7 @@ listen_addresses = '*'		# what IP address(es) to listen on;
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
 port = 5432				# (change requires restart)
-max_connections = 100			# (change requires restart)
+max_connections = PG_MAX_CONNECTIONS	# (change requires restart)
 #reserved_connections = 0		# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 #unix_socket_directories = '/run/postgresql' # comma-separated list of directories
@@ -94,7 +94,7 @@ max_connections = 100			# (change requires restart)
 # - Authentication -
 
 #authentication_timeout = 1min		# 1s-600s
-password_encryption = scram-sha-256	# scram-sha-256 or md5
+password_encryption = PG_PASSWORD_ENCRYPTION	# scram-sha-256 or md5
 #scram_iterations = 4096
 #md5_password_warnings = on
 #oauth_validator_libraries = ''	# comma-separated list of trusted validator modules
@@ -129,7 +129,7 @@ ssl_key_file = 'server.key'
 
 # - Memory -
 
-shared_buffers = 256MB			# min 128kB
+shared_buffers = PG_SHARED_BUFFERSMB	# min 128kB
 					# (change requires restart)
 #huge_pages = try			# on, off, or try
 					# (change requires restart)
@@ -140,7 +140,7 @@ max_prepared_transactions = 100		# zero disables the feature
 					# (change requires restart)
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
-work_mem = 4MB				# min 64kB
+work_mem = PG_WORK_MEMMB			# min 64kB
 #hash_mem_multiplier = 2.0		# 1-1000.0 multiplier on hash table work_mem
 #maintenance_work_mem = 64MB		# min 64kB
 #autovacuum_work_mem = -1		# min 64kB, or -1 to use maintenance_work_mem
@@ -217,7 +217,7 @@ dynamic_shared_memory_type = posix	# the default is usually the first option
 max_worker_processes = 8		# (change requires restart)
 max_parallel_workers_per_gather = 2	# limited by max_parallel_workers
 #max_parallel_maintenance_workers = 2	# limited by max_parallel_workers
-max_parallel_workers = 2		# number of max_worker_processes that
+max_parallel_workers = PG_MAX_PARALLEL_WORKERS	# number of max_worker_processes that
 					# can be used in parallel operations
 #parallel_leader_participation = on
 
@@ -264,7 +264,7 @@ checkpoint_timeout = 30min		# range 30s-1d
 checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_flush_after = 256kB		# measured in pages, 0 disables
 #checkpoint_warning = 30s		# 0 disables
-max_wal_size = 1GB
+max_wal_size = PG_MAX_WAL_SIZEGB
 min_wal_size = 256MB
 
 # - Prefetching during recovery -
@@ -440,7 +440,7 @@ hot_standby = on			# "off" disallows queries during recovery
 #parallel_tuple_cost = 0.1		# same scale as above
 #min_parallel_table_scan_size = 8MB
 #min_parallel_index_scan_size = 512kB
-effective_cache_size = 1GB
+effective_cache_size = PG_EFFECTIVE_CACHE_SIZEGB
 
 #jit_above_cost = 100000		# perform JIT compilation if available
 					# and query more expensive than this;


### PR DESCRIPTION
## Summary

The `run-postgresql` startup script replaces placeholder tokens in
`postgresql.conf` via `sed`, but the config template contained
hardcoded values instead of the expected tokens. All tuning
environment variables documented in the README were no-ops.

## Changes

**File:** `pgsql18-primary-rocky10/conf/postgresql.conf`

| Parameter | Before (hardcoded) | After (placeholder) |
|-----------|-------------------|-------------------|
| `max_connections` | `100` | `PG_MAX_CONNECTIONS` |
| `shared_buffers` | `256MB` | `PG_SHARED_BUFFERSMB` |
| `work_mem` | `4MB` | `PG_WORK_MEMMB` |
| `max_parallel_workers` | `2` | `PG_MAX_PARALLEL_WORKERS` |
| `effective_cache_size` | `1GB` | `PG_EFFECTIVE_CACHE_SIZEGB` |
| `max_wal_size` | `1GB` | `PG_MAX_WAL_SIZEGB` |
| `password_encryption` | `scram-sha-256` | `PG_PASSWORD_ENCRYPTION` |

The replica image is not affected — it receives its `postgresql.conf`
from `pg_basebackup` (copying the primary's already-substituted
config), not from a local template.

## Verification

With defaults (`PG_MAX_CONNECTIONS=100`, `PG_SHARED_BUFFERS=256`, etc.),
the sed replacements produce the same values that were previously
hardcoded. With custom values, the config now correctly reflects them.

Fixes #12