### PR TITLE
[#21] Add .dockerignore to pgsql18-replica-rocky10

### DIFF
--- a/pgsql18-replica-rocky10/.dockerignore
+++ b/pgsql18-replica-rocky10/.dockerignore
@@ -1,0 +1,2 @@
+Makefile
+README.md


### PR DESCRIPTION
The primary and pgmoneta image directories have `.dockerignore` files
(added in #15), but the replica directory was added later (#3) and is
missing one.

Add a matching `.dockerignore` to `pgsql18-replica-rocky10/` that
excludes `Makefile` and `README.md` from the build context.

Fixes #21