### PR TITLE
Build infrastructure (#8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,20 @@
 # PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
 # OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
 #
-IMAGE_NAME = pgmoneta-rocky10
+IMAGES = \
+	pgexporter-rocky10 \
+	pgmoneta-rocky10 \
+	pgsql18-primary-rocky10 \
+	pgsql18-replica-rocky10
 
-.PHONY: build clean
-build:
-	podman build --no-cache -t $(IMAGE_NAME) .
+.PHONY: build clean $(IMAGES)
+
+build: $(IMAGES)
+
+$(IMAGES):
+	$(MAKE) -C $@ build
 
 clean:
-	podman rmi -f $(IMAGE_NAME) 2>/dev/null || true
+	@for img in $(IMAGES); do \
+		$(MAKE) -C $$img clean; \
+	done

--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ The images makes use of
 Images are provided **`AS IS`** according to the license agreement with
 no guarantees of correctness and stability.
 
+## Building
+
+Build all images and install them locally:
+
+```
+make build
+```
+
+Build a single image:
+
+```
+make pgsql18-primary-rocky10
+```
+
+Remove all images:
+
+```
+make clean
+```
+
 ## License
 
 All images are released under the [Eclipse Public License - v2.0](https://www.eclipse.org/legal/epl-2.0/)

--- a/pgexporter-rocky10/Makefile
+++ b/pgexporter-rocky10/Makefile
@@ -7,6 +7,9 @@
 #
 IMAGE_NAME = pgexporter-rocky10
 
-.PHONY: build
+.PHONY: build clean
 build:
 	podman build --no-cache -t $(IMAGE_NAME) .
+
+clean:
+	podman rmi -f $(IMAGE_NAME) 2>/dev/null || true

--- a/pgsql18-primary-rocky10/Makefile
+++ b/pgsql18-primary-rocky10/Makefile
@@ -7,6 +7,9 @@
 #
 IMAGE_NAME = pgsql18-primary-rocky10
 
-.PHONY: build
+.PHONY: build clean
 build:
 	podman build --no-cache -t $(IMAGE_NAME) .
+
+clean:
+	podman rmi -f $(IMAGE_NAME) 2>/dev/null || true

--- a/pgsql18-replica-rocky10/Makefile
+++ b/pgsql18-replica-rocky10/Makefile
@@ -7,6 +7,9 @@
 #
 IMAGE_NAME = pgsql18-replica-rocky10
 
-.PHONY: build
+.PHONY: build clean
 build:
 	podman build --no-cache -t $(IMAGE_NAME) .
+
+clean:
+	podman rmi -f $(IMAGE_NAME) 2>/dev/null || true


### PR DESCRIPTION
Fixes #8. Adds a top-level Makefile to build all images and expands clean targets.